### PR TITLE
add a deadlock test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ futures = "0.1"
 log = "0.4"
 
 [dev-dependencies]
-tokio = "0.1"
 tokio-core = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ futures = "0.1"
 log = "0.4"
 
 [dev-dependencies]
+tokio = "0.1"
 tokio-core = "0.1"


### PR DESCRIPTION
@realcr @kamyuentse 
Hey, I have a deadlock here. The key point is polling `task2` before `task1`.