### PR TITLE
Continue on #6

### DIFF
--- a/src/acquire_borrow.rs
+++ b/src/acquire_borrow.rs
@@ -80,7 +80,7 @@ impl<T> AsyncMutex<T> {
             // The resource is received.
             let result = f(&mut t);
             wakeup_next(inner, t);
-            result.into_future().map_err(|e| AsyncMutexError::Function(e))
+            result.into_future().map_err(AsyncMutexError::Function)
         })
     }
 }
@@ -284,5 +284,4 @@ mod tests {
 
         assert_eq!(core.run(task2).unwrap(), 1);
     }
-
 }


### PR DESCRIPTION
Main difference is using `and_then` combinator instead of the old state machine (AcquireFutureState).
The only manual future implementation is `WaitPoll`, which is equivalent to `NotPolled` in the old code.

Let me know what you think about this design.