### PR TITLE
Rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["real <real@freedomlayer.org>", "Kamyuen Tse <kevin.xjy@gmail.com>", 
 
 [dependencies]
 futures = "0.1"
-log = "0.4"
 
 [dev-dependencies]
 tokio-core = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["real <real@freedomlayer.org>", "Kamyuen Tse <kevin.xjy@gmail.com>", 
 futures = "0.1"
 
 [dev-dependencies]
-tokio-core = "0.1"
+tokio = "0.1.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,7 @@ impl<T> Clone for AsyncMutex<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::AsyncMutex;
-    use tokio::prelude::*;
+    use super::*;
     use tokio::runtime::current_thread::Runtime;
 
     struct NumCell {
@@ -319,12 +318,12 @@ mod tests {
             Ok((num_cell, ()))
         });
 
-        assert!(runtime.block_on(task1).is_err());
+        assert_eq!(runtime.block_on(task1), Err(AsyncMutexError::Function(())));
 
         assert_eq!(runtime.block_on(task2).unwrap(), 1);
 
-        assert!(runtime.block_on(task3).is_err());
-        assert!(runtime.block_on(task4).is_err());
+        assert_eq!(runtime.block_on(task3), Err(AsyncMutexError::Function(())));
+        assert_eq!(runtime.block_on(task4), Err(AsyncMutexError::ResourceBroken));
     }
 
     #[test]
@@ -447,7 +446,7 @@ mod tests {
 
         let task1 = async_mutex.acquire_borrow(|_| -> Result<(), _> { Err(()) });
 
-        assert!(runtime.block_on(task1).is_err());
+        assert_eq!(runtime.block_on(task1), Err(AsyncMutexError::Function(())));
 
         let task2 = async_mutex.acquire_borrow(|num_cell| -> Result<_, ()> {
             num_cell.num += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,60 +1,57 @@
 extern crate futures;
-#[macro_use]
-extern crate log;
 #[cfg(test)]
 extern crate tokio_core;
 
 use std::cell::RefCell;
-use std::mem;
 use std::rc::Rc;
+use std::marker::PhantomData;
 
+use futures::future;
 use futures::prelude::*;
 use futures::sync::oneshot;
 
 use std::collections::LinkedList;
 
-pub mod acquire_borrow;
-
 #[derive(Debug)]
-enum ResourceState<T> {
-    Empty,
-    Broken,
-    Pending(LinkedList<oneshot::Sender<T>>),
-    Present(T),
+struct Awakener<T> {
+    queue: LinkedList<oneshot::Sender<T>>,
 }
 
-#[derive(Debug)]
-pub struct Inner<T> {
-    resource: ResourceState<T>,
-}
-
-impl<T> Inner<T> {
-    fn wakeup_next(&mut self, resource: T) {
-        if let ResourceState::Pending(mut awakeners) =
-            mem::replace(&mut self.resource, ResourceState::Empty)
-        {
-            let mut bucket = Some(resource);
-
-            while let Some(awakener) = awakeners.pop_front() {
-                let resource = bucket
-                    .take()
-                    .expect("Attempted to take resource after it gone");
-
-                match awakener.send(resource) {
-                    Ok(_) => break,
-                    Err(resource) => {
-                        bucket = Some(resource);
-                        continue;
-                    }
-                }
-            }
-
-            self.resource = match bucket {
-                Some(t) => ResourceState::Present(t),
-                None => ResourceState::Pending(awakeners),
-            }
+impl<T> Awakener<T> {
+    fn new() -> Awakener<T> {
+        Awakener {
+            queue: LinkedList::new(),
         }
     }
+
+    /// Try to send the resource.
+    /// Return `None` if succeed.
+    /// Return `Some(resource)` if failed.
+    fn wakeup_next(&mut self, mut resource: T) -> Option<T> {
+        while let Some(sender) = self.queue.pop_front() {
+            resource = match sender.send(resource) {
+                Ok(_) => return None,
+                Err(resource) => resource,
+            }
+        }
+        Some(resource)
+    }
+
+    /// Make a pair of `(sender, receiver)`.
+    /// `sender` is pushed to `self.queue`.
+    /// Return `receiver`.
+    fn add_awakener(&mut self) -> oneshot::Receiver<T> {
+        let (sender, receiver) = oneshot::channel();
+        self.queue.push_back(sender);
+        receiver
+    }
+}
+
+#[derive(Debug)]
+enum Inner<T> {
+    Empty,
+    Present(T),
+    Pending(Awakener<T>),
 }
 
 #[derive(Debug)]
@@ -62,262 +59,111 @@ pub struct AsyncMutex<T> {
     inner: Rc<RefCell<Inner<T>>>,
 }
 
+
+impl<T> AsyncMutex<T> {
+    pub fn new(resource: T) -> AsyncMutex<T> {
+        AsyncMutex {
+            inner: Rc::new(RefCell::new(Inner::Present(resource))),
+        }
+    }
+
+    pub fn acquire_borrow<F, B, O, E>(&self, f: F) -> impl Future<Item = O, Error = AsyncMutexError<E>>
+    where
+        F: FnOnce(&mut T) -> B,
+        B: IntoFuture<Item = O, Error = E>,
+    {
+        WaitPoll {
+            inner: Rc::clone(&self.inner),
+            marker: Default::default(),
+        }.and_then(|(inner, receiver)| {
+            // Wait until we receive the resource via `receiver`
+            (future::ok(inner), receiver)
+                .into_future()
+                .map_err(|_| AsyncMutexError::AwakenerCanceled)
+        }).and_then(move |(inner, mut t)| {
+            // The resource is received.
+            let result = f(&mut t);
+            wakeup_next(inner, t);
+            result.into_future().map_err(AsyncMutexError::Function)
+        })
+    }
+}
+
+/// Call Awakener::wakeup_next(), and set the state accordingly
+fn wakeup_next<T>(inner: Rc<RefCell<Inner<T>>>, t: T) {
+    let state = inner.replace(Inner::Empty);
+    if let Inner::Pending(mut awakener) = state {
+        let next_state = match awakener.wakeup_next(t) {
+            Some(t) => Inner::Present(t),
+            None => Inner::Pending(awakener),
+        };
+        inner.replace(next_state);
+    } else {
+        // We are holding the resource in `t`,
+        // so it's impossible that the resource is also in `Inner::Present`
+        //
+        // T as a generic type is not clone-able nor copy-able,
+        // so this cannot happen.
+        unreachable!()
+    }
+}
+
+/// This struct is a future.
+/// It resolves immediately to `(inner, f, receiver)`,
+/// where `receiver` is a `oneshot::Receiver<T>`.
+///
+/// This struct is introduced so that `AsyncMutex::acquire_borrow`
+/// will so nothing unless polled.
+#[derive(Debug)]
+struct WaitPoll<T, E> {
+    inner: Rc<RefCell<Inner<T>>>,
+    marker: PhantomData<E>,
+}
+
+impl<T, E> Future for WaitPoll<T, E> {
+    type Item = (Rc<RefCell<Inner<T>>>, oneshot::Receiver<T>);
+    type Error = AsyncMutexError<E>;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let inner = self.inner.replace(Inner::Empty);
+
+        let receiver = match inner {
+            Inner::Pending(mut awakener) => {
+                // Already in pending state, we just need to add a new awakener.
+                let receiver = awakener.add_awakener();
+                self.inner.replace(Inner::Pending(awakener));
+                receiver
+            }
+            Inner::Present(t) => {
+                // Resource is available,
+                // add a new awakener and then wake up it at once.
+                let mut awakener = Awakener::new();
+                let receiver = awakener.add_awakener();
+                match awakener.wakeup_next(t) {
+                    Some(t) => {
+                        self.inner.replace(Inner::Present(t));
+                        return Err(AsyncMutexError::AwakenerCanceled);
+                    }
+                    None => {
+                        self.inner.replace(Inner::Pending(awakener));
+                        receiver
+                    }
+                }
+            }
+            Inner::Empty => unreachable!(),
+        };
+
+        Ok(Async::Ready((
+            Rc::clone(&self.inner),
+            receiver,
+        )))
+    }
+}
+
 #[derive(Debug)]
 pub enum AsyncMutexError<E> {
     AwakenerCanceled,
-    ResourceBroken,
     Function(E),
-}
-
-impl<E> From<E> for AsyncMutexError<E> {
-    fn from(e: E) -> AsyncMutexError<E> {
-        AsyncMutexError::Function(e)
-    }
-}
-
-#[derive(Debug)]
-enum AcquireFutureState<T, F, G> {
-    NotPolled(F),
-    WaitResource((oneshot::Receiver<T>, F)),
-    WaitFunction(G),
-    Broken,
-    Empty,
-}
-
-#[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
-pub struct AcquireFuture<T, F, G, A> {
-    inner: Rc<RefCell<Inner<T>>>,
-    state: AcquireFutureState<T, F, G>,
-    marker: std::marker::PhantomData<A>,
-}
-
-pub struct Move;
-pub struct Borrow;
-
-impl<T> AsyncMutex<T> {
-    /// Create a new **single threading** shared mutex resource.
-    pub fn new(t: T) -> AsyncMutex<T> {
-        let inner = Rc::new(RefCell::new(Inner {
-            resource: ResourceState::Present(t),
-        }));
-
-        AsyncMutex { inner }
-    }
-
-    /// Acquire a shared resource (in the same thread) and invoke the function `f` over it.
-    ///
-    /// The `f` MUST return an `IntoFuture` that resolves to a tuple of the form (res, output),
-    /// where `t` is the original `resource`, and `output` is custom output.
-    ///
-    /// If the acquirer produce get into trouble,he can choose to consume the resource by returning
-    /// `(None, e)`, or give back the resource by returning `(Some(res), e)`.
-    ///
-    /// This function returns a future that resolves to the value given at output.
-    pub fn acquire<F, B, E, G, O>(&self, f: F) -> AcquireFuture<T, F, G, Move>
-    where
-        F: FnOnce(T) -> B,
-        G: Future<Item = (T, O), Error = (Option<T>, E)>,
-        B: IntoFuture<Item = G::Item, Error = G::Error, Future = G>,
-    {
-        AcquireFuture {
-            inner: Rc::clone(&self.inner),
-            state: AcquireFutureState::NotPolled(f),
-            marker: Default::default(),
-        }
-    }
-
-    pub fn acquire_borrow<F, B, E, G, O>(&self, f: F) -> AcquireFuture<T, F, G, Borrow>
-    where
-        F: FnOnce(&mut T) -> B,
-        G: Future<Item = O, Error = E>,
-        B: IntoFuture<Item = G::Item, Error = G::Error, Future = G>,
-    {
-        AcquireFuture {
-            inner: Rc::clone(&self.inner),
-            state: AcquireFutureState::NotPolled(f),
-            marker: Default::default(),
-        }
-    }
-}
-
-impl<T, F, B, G, E, O> Future for AcquireFuture<T, F, G, Borrow>
-where
-    F: FnOnce(&mut T) -> B,
-    G: Future<Item = O, Error = E>,
-    B: IntoFuture<Item = G::Item, Error = G::Error, Future = G>,
-{
-    type Item = O;
-    type Error = AsyncMutexError<E>;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            match mem::replace(&mut self.state, AcquireFutureState::Empty) {
-                AcquireFutureState::Empty => unreachable!(),
-                AcquireFutureState::NotPolled(f) => {
-                    let resource =
-                        mem::replace(&mut self.inner.borrow_mut().resource, ResourceState::Empty);
-                    match resource {
-                        ResourceState::Empty => unreachable!(),
-                        ResourceState::Pending(mut awakeners) => {
-                            let mut inner = self.inner.borrow_mut();
-                            let (awakener, waiter) = oneshot::channel::<T>();
-                            awakeners.push_back(awakener);
-                            inner.resource = ResourceState::Pending(awakeners);
-                            self.state = AcquireFutureState::WaitResource((waiter, f));
-                        }
-                        ResourceState::Present(mut t) => {
-                            self.inner.borrow_mut().resource =
-                                ResourceState::Pending(LinkedList::new());
-                            self.state = AcquireFutureState::WaitFunction(f(&mut t).into_future());
-                            self.inner.borrow_mut().wakeup_next(t);
-                        }
-                        ResourceState::Broken => {
-                            self.inner.borrow_mut().resource = ResourceState::Broken;
-                            self.state = AcquireFutureState::Broken;
-                        }
-                    }
-                }
-                AcquireFutureState::Broken => {
-                    return Err(AsyncMutexError::ResourceBroken);
-                }
-                AcquireFutureState::WaitResource((mut waiter, f)) => {
-                    if let ResourceState::Broken = self.inner.borrow().resource {
-                        return Err(AsyncMutexError::ResourceBroken);
-                    }
-                    match waiter
-                        .poll()
-                        .map_err(|_| AsyncMutexError::AwakenerCanceled)?
-                    {
-                        Async::Ready(mut t) => {
-                            trace!("AcquireFuture::WaitResource -- Ready");
-
-                            self.state = AcquireFutureState::WaitFunction(f(&mut t).into_future());
-                            self.inner.borrow_mut().wakeup_next(t);
-                        }
-                        Async::NotReady => {
-                            trace!("AcquireFuture::WaitResource -- NotReady");
-
-                            self.state = AcquireFutureState::WaitResource((waiter, f));
-                            return Ok(Async::NotReady);
-                        }
-                    }
-                }
-                AcquireFutureState::WaitFunction(mut f) => match f.poll() {
-                    Err(acquirer_error) => {
-                        return Err(AsyncMutexError::Function(acquirer_error));
-                    }
-                    Ok(Async::NotReady) => {
-                        trace!("AcquireFuture::WaitFunction -- NotReady");
-
-                        self.state = AcquireFutureState::WaitFunction(f);
-                        return Ok(Async::NotReady);
-                    }
-                    Ok(Async::Ready(output)) => {
-                        trace!("AcquireFuture::WaitFunction -- Ready");
-
-                        return Ok(Async::Ready(output));
-                    }
-                },
-            }
-        }
-    }
-}
-
-impl<T, F, B, G, E, O> Future for AcquireFuture<T, F, G, Move>
-where
-    F: FnOnce(T) -> B,
-    G: Future<Item = (T, O), Error = (Option<T>, E)>,
-    B: IntoFuture<Item = G::Item, Error = G::Error, Future = G>,
-{
-    type Item = O;
-    type Error = AsyncMutexError<E>;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            match mem::replace(&mut self.state, AcquireFutureState::Empty) {
-                AcquireFutureState::Empty => unreachable!(),
-                AcquireFutureState::NotPolled(f) => {
-                    let resource =
-                        mem::replace(&mut self.inner.borrow_mut().resource, ResourceState::Empty);
-                    match resource {
-                        ResourceState::Empty => unreachable!(),
-                        ResourceState::Pending(mut awakeners) => {
-                            let mut inner = self.inner.borrow_mut();
-                            let (awakener, waiter) = oneshot::channel::<T>();
-                            awakeners.push_back(awakener);
-                            inner.resource = ResourceState::Pending(awakeners);
-                            self.state = AcquireFutureState::WaitResource((waiter, f));
-                        }
-                        ResourceState::Present(t) => {
-                            self.inner.borrow_mut().resource =
-                                ResourceState::Pending(LinkedList::new());
-                            self.state = AcquireFutureState::WaitFunction(f(t).into_future());
-                        }
-                        ResourceState::Broken => {
-                            let mut inner = self.inner.borrow_mut();
-                            inner.resource = ResourceState::Broken;
-                            self.state = AcquireFutureState::Broken;
-                        }
-                    }
-                }
-                AcquireFutureState::Broken => {
-                    return Err(AsyncMutexError::ResourceBroken);
-                }
-                AcquireFutureState::WaitResource((mut waiter, f)) => {
-                    if let ResourceState::Broken = self.inner.borrow().resource {
-                        return Err(AsyncMutexError::ResourceBroken);
-                    }
-                    match waiter
-                        .poll()
-                        .map_err(|_| AsyncMutexError::AwakenerCanceled)?
-                    {
-                        Async::Ready(t) => {
-                            trace!("AcquireFuture::WaitResource -- Ready");
-
-                            self.state = AcquireFutureState::WaitFunction(f(t).into_future());
-                        }
-                        Async::NotReady => {
-                            trace!("AcquireFuture::WaitResource -- NotReady");
-
-                            self.state = AcquireFutureState::WaitResource((waiter, f));
-                            return Ok(Async::NotReady);
-                        }
-                    }
-                }
-                AcquireFutureState::WaitFunction(mut f) => match f.poll() {
-                    Err((resource, acquirer_error)) => {
-                        let mut inner = self.inner.borrow_mut();
-                        if let Some(resource) = resource {
-                            inner.wakeup_next(resource);
-                        } else {
-                            inner.resource = ResourceState::Broken;
-                        }
-                        return Err(AsyncMutexError::Function(acquirer_error));
-                    }
-                    Ok(Async::NotReady) => {
-                        trace!("AcquireFuture::WaitFunction -- NotReady");
-
-                        self.state = AcquireFutureState::WaitFunction(f);
-                        return Ok(Async::NotReady);
-                    }
-                    Ok(Async::Ready((resource, output))) => {
-                        trace!("AcquireFuture::WaitFunction -- Ready");
-                        self.inner.borrow_mut().wakeup_next(resource);
-                        return Ok(Async::Ready(output));
-                    }
-                },
-            }
-        }
-    }
-}
-
-impl<T> Clone for AsyncMutex<T> {
-    fn clone(&self) -> AsyncMutex<T> {
-        AsyncMutex {
-            inner: Rc::clone(&self.inner),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -327,149 +173,6 @@ mod tests {
 
     struct NumCell {
         num: usize,
-    }
-
-    #[test]
-    fn simple() {
-        let mut core = Core::new().unwrap();
-        let async_mutex = AsyncMutex::new(NumCell { num: 0 });
-
-        let task1 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        assert_eq!(core.run(task1).unwrap(), ());
-
-        {
-            let _ = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-                num_cell.num += 1;
-                Ok((num_cell, ()))
-            });
-
-            let _ = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-                num_cell.num += 1;
-                Ok((num_cell, ()))
-            });
-        }
-
-        let task2 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-
-            let num = num_cell.num;
-            Ok((num_cell, num))
-        });
-
-        assert_eq!(core.run(task2).unwrap(), 2);
-    }
-
-    #[test]
-    fn multiple() {
-        const N: usize = 1_000;
-
-        let mut core = Core::new().unwrap();
-
-        let async_mutex = AsyncMutex::new(NumCell { num: 0 });
-
-        for num in 0..N {
-            let task = async_mutex.acquire(move |mut num_cell| -> Result<_, (_, ())> {
-                assert_eq!(num_cell.num, num);
-
-                num_cell.num += 1;
-                Ok((num_cell, ()))
-            });
-
-            assert_eq!(core.run(task).unwrap(), ());
-        }
-
-        let task = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            let num = num_cell.num;
-            Ok((num_cell, num))
-        });
-
-        assert_eq!(core.run(task).unwrap(), N + 1);
-    }
-
-    #[test]
-    fn nested() {
-        let mut core = Core::new().unwrap();
-
-        let async_mutex = AsyncMutex::new(NumCell { num: 0 });
-
-        let task = async_mutex
-            .clone()
-            .acquire(move |mut num_cell| -> Result<_, (_, ())> {
-                num_cell.num += 1;
-
-                let mut nested_task = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-                    assert_eq!(num_cell.num, 1);
-                    num_cell.num += 1;
-                    Ok((num_cell, ()))
-                });
-                assert_eq!(nested_task.poll().unwrap(), Async::NotReady);
-
-                let num = num_cell.num;
-                Ok((num_cell, num))
-            });
-
-        assert_eq!(core.run(task).unwrap(), 1);
-    }
-
-    #[test]
-    fn error() {
-        let mut core = Core::new().unwrap();
-
-        let async_mutex = AsyncMutex::new(NumCell { num: 0 });
-
-        let task1 =
-            async_mutex.acquire(|num_cell| -> Result<(_, ()), _> { Err((Some(num_cell), ())) });
-
-        let task2 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            let num = num_cell.num;
-            Ok((num_cell, num))
-        });
-
-        let task3 = async_mutex.acquire(|_| -> Result<(_, ()), _> { Err((None, ())) });
-
-        let task4 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        assert!(core.run(task1).is_err());
-
-        assert_eq!(core.run(task2).unwrap(), 1);
-
-        assert!(core.run(task3).is_err());
-        assert!(core.run(task4).is_err());
-    }
-
-    #[test]
-    fn deadlock() {
-        let mut core = Core::new().unwrap();
-
-        let async_mutex = AsyncMutex::new(NumCell { num: 0 });
-
-        let task0 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        let task1 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        let task2 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        core.run(task0).unwrap();
-        core.run(task2).unwrap();
-        core.run(task1).unwrap();
     }
 
     #[test]
@@ -577,32 +280,12 @@ mod tests {
 
         assert_eq!(core.run(task2).unwrap(), 1);
     }
-
-    #[test]
-    fn mixed() {
-        let mut core = Core::new().unwrap();
-
-        let async_mutex = AsyncMutex::new(NumCell { num: 0 });
-
-        let task1 = async_mutex.acquire(|mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        let task2 = async_mutex.acquire_borrow(|num_cell| -> Result<_, ()> {
-            num_cell.num += 1;
-            Ok(())
-        });
-
-        let task3 = async_mutex.acquire(move |mut num_cell| -> Result<_, (_, ())> {
-            num_cell.num += 1;
-            Ok((num_cell, ()))
-        });
-
-        core.run((task1, task2, task3).into_future()).unwrap();
-
-        let task = async_mutex.acquire_borrow(|num_cell| -> Result<_, ()> { Ok(num_cell.num) });
-
-        assert_eq!(core.run(task).unwrap(), 3);
+}
+impl<T> Clone for AsyncMutex<T> {
+    fn clone(&self) -> AsyncMutex<T> {
+        AsyncMutex {
+            inner: Rc::clone(&self.inner),
+        }
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ impl<T, E> Future for WaitPoll<T, E> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum AsyncMutexError<E> {
     ResourceBroken,
     AwakenerCanceled,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ pub struct AsyncMutex<T> {
     inner: Rc<RefCell<Inner<T>>>,
 }
 
-
 impl<T> AsyncMutex<T> {
     pub fn new(resource: T) -> AsyncMutex<T> {
         AsyncMutex {
@@ -78,9 +77,7 @@ impl<T> AsyncMutex<T> {
             marker: Default::default(),
         }.and_then(|receiver| {
             // Wait until we receive the resource via `receiver`
-            receiver
-                .into_future()
-                .map_err(|_| AsyncMutexError::AwakenerCanceled)
+            receiver.map_err(|_| AsyncMutexError::AwakenerCanceled)
         }).and_then(move |mut t| {
             // The resource is received.
             let result = f(&mut t);
@@ -100,9 +97,7 @@ impl<T> AsyncMutex<T> {
             marker: Default::default(),
         }.and_then(|receiver| {
             // Wait until we receive the resource via `receiver`
-            receiver
-                .into_future()
-                .map_err(|_| AsyncMutexError::AwakenerCanceled)
+            receiver.map_err(|_| AsyncMutexError::AwakenerCanceled)
         }).and_then(move |t| {
             // The resource is received.
            f(t).into_future().then(move |result| match result {


### PR DESCRIPTION
@realcr 

- Rewrite code, as discussed in #11 
- Rewrite tests using `tokio` and `Runtime`
- Implement some common traits on `AsyncMutexError`
- Make error tests more specific